### PR TITLE
refactor(action): restructure tests using patch decorator

### DIFF
--- a/test_merge_checks.py
+++ b/test_merge_checks.py
@@ -4,91 +4,91 @@ from unittest.mock import patch
 import merge_checks
 
 
-def patch_fetch_head_only():
-    return patch.object(merge_checks, "fetch_head_only")
-
-
-def patch_get_base_revision(result: str):
-    return patch.object(merge_checks, "get_base_revision", return_value=result)
-
-
-def patch_fetch_full_history():
-    return patch.object(merge_checks, "fetch_full_history")
-
-
-def patch_get_subject_markers(*markers: str):
-    return patch.object(merge_checks, "get_subject_markers", return_value=tuple(markers))
-
-
-def patch_has_merge_commits(result: bool):
-    return patch.object(merge_checks, "has_merge_commits", return_value=result)
-
-
+@patch.object(merge_checks, "has_merge_commits")
+@patch.object(merge_checks, "get_subject_markers")
+@patch.object(merge_checks, "fetch_full_history")
+@patch.object(merge_checks, "get_base_revision")
+@patch.object(merge_checks, "fetch_head_only")
 class MergeCheckTest(TestCase):
-    def test_happy_path(self):
+
+    def test_happy_path(self, fetch_head_only, get_base_revision, fetch_full_history, get_subject_markers,
+                        has_merge_commits):
         head_hash = "987xyz"
         base_ref = "baseref"
         base_hash = "123abc"
 
-        with patch_fetch_head_only() as fetch_head_only_mock, \
-                patch_get_base_revision(base_hash) as get_base_revision_mock, \
-                patch_fetch_full_history() as fetch_full_history_mock, \
-                patch_get_subject_markers("firstsubjectword") as get_subject_markers_mock, \
-                patch_has_merge_commits(False) as has_merge_commits_mock:
-            self.assertEqual(0, merge_checks.main(head_hash, base_ref))
-            fetch_head_only_mock.assert_called_once_with(base_ref)
-            get_base_revision_mock.assert_called_once_with(base_ref)
-            fetch_full_history_mock.assert_called_once()
-            get_subject_markers_mock.assert_called_once_with(head_hash, base_hash)
-            has_merge_commits_mock.assert_called_once_with(head_hash, base_hash)
+        get_base_revision.return_value = base_hash
+        get_subject_markers.return_value = ("feat(component):",)
+        has_merge_commits.return_value = False
 
-    def test_early_exit_no_commits(self):
+        self.assertEqual(0, merge_checks.main(head_hash=head_hash, base_ref=base_ref))
+        fetch_head_only.assert_called_once_with(base_ref)
+        get_base_revision.assert_called_once_with(base_ref)
+        fetch_full_history.assert_called_once()
+        get_subject_markers.assert_called_once_with(head_hash, base_hash)
+        has_merge_commits.assert_called_once_with(head_hash, base_hash)
+
+    def test_early_exit_no_commits(self, fetch_head_only, get_base_revision, fetch_full_history, get_subject_markers,
+                                   has_merge_commits):
         base_ref = "baseref"
         base_hash = "123abc"
 
-        with patch_fetch_head_only() as fetch_head_only_mock, \
-                patch_get_base_revision(base_hash) as get_base_revision_mock, \
-                patch_fetch_full_history() as fetch_full_history_mock, \
-                patch_get_subject_markers() as get_subject_markers_mock, \
-                patch_has_merge_commits(False) as has_merge_commits_mock:
-            self.assertEqual(0, merge_checks.main(base_hash, base_ref))
-            fetch_head_only_mock.assert_called_once_with(base_ref)
-            get_base_revision_mock.assert_called_once_with(base_ref)
-            fetch_full_history_mock.assert_not_called()
-            get_subject_markers_mock.assert_not_called()
-            has_merge_commits_mock.assert_not_called()
+        get_base_revision.return_value = base_hash
+        has_merge_commits.return_value = False
 
-    def test_fixup_squash_found(self):
+        self.assertEqual(0, merge_checks.main(head_hash=base_hash, base_ref=base_ref))
+        fetch_head_only.assert_called_once_with(base_ref)
+        get_base_revision.assert_called_once_with(base_ref)
+        fetch_full_history.assert_not_called()
+        get_subject_markers.assert_not_called()
+        has_merge_commits.assert_not_called()
+
+    def test_fixup_found(self, fetch_head_only, get_base_revision, fetch_full_history, get_subject_markers,
+                         has_merge_commits):
+        head_hash = "987xyz"
+        base_ref = "baseref"
+        base_hash = "123abc"
+        get_base_revision.return_value = base_hash
+        get_subject_markers.return_value = ("feat(component):", "fixup!")
+        has_merge_commits.return_value = False
+
+        self.assertEqual(1, merge_checks.main(head_hash=head_hash, base_ref=base_ref))
+        fetch_head_only.assert_called_once_with(base_ref)
+        get_base_revision.assert_called_once_with(base_ref)
+        fetch_full_history.assert_called_once()
+        get_subject_markers.assert_called_once_with(head_hash, base_hash)
+        has_merge_commits.assert_not_called()
+
+    def test_squash_found(self, fetch_head_only, get_base_revision, fetch_full_history, get_subject_markers,
+                          has_merge_commits):
         head_hash = "987xyz"
         base_ref = "baseref"
         base_hash = "123abc"
 
-        for marker in ("fixup!", "squash!"):
-            with patch_fetch_head_only() as fetch_head_only_mock, \
-                    patch_get_base_revision(base_hash) as get_base_revision_mock, \
-                    patch_fetch_full_history() as fetch_full_history_mock, \
-                    patch_get_subject_markers("feat(component):", marker) as get_subject_markers_mock, \
-                    patch_has_merge_commits(False) as has_merge_commits_mock:
-                self.assertEqual(1, merge_checks.main(head_hash, base_ref))
-                fetch_head_only_mock.assert_called_once_with(base_ref)
-                get_base_revision_mock.assert_called_once_with(base_ref)
-                fetch_full_history_mock.assert_called_once()
-                get_subject_markers_mock.assert_called_once_with(head_hash, base_hash)
-                has_merge_commits_mock.assert_not_called()
+        get_base_revision.return_value = base_hash
+        get_subject_markers.return_value = ("feat(component):", "squash!")
+        has_merge_commits.return_value = False
 
-    def test_merge_commit_found(self):
+        self.assertEqual(1, merge_checks.main(head_hash=head_hash, base_ref=base_ref))
+        fetch_head_only.assert_called_once_with(base_ref)
+        get_base_revision.assert_called_once_with(base_ref)
+        fetch_full_history.assert_called_once()
+        get_subject_markers.assert_called_once_with(head_hash, base_hash)
+        has_merge_commits.assert_not_called()
+
+    def test_merge_commit_found(self, fetch_head_only, get_base_revision, fetch_full_history, get_subject_markers,
+                                has_merge_commits):
         head_hash = "987xyz"
         base_ref = "baseref"
         base_hash = "123abc"
 
-        with patch_fetch_head_only() as fetch_head_only_mock, \
-                patch_get_base_revision(base_hash) as get_base_revision_mock, \
-                patch_fetch_full_history() as fetch_full_history_mock, \
-                patch_get_subject_markers("feat(component):") as get_subject_markers_mock, \
-                patch_has_merge_commits(True) as has_merge_commits_mock:
-            self.assertEqual(1, merge_checks.main(head_hash, base_ref))
-            fetch_head_only_mock.assert_called_once_with(base_ref)
-            get_base_revision_mock.assert_called_once_with(base_ref)
-            fetch_full_history_mock.assert_called_once()
-            get_subject_markers_mock.assert_called_once_with(head_hash, base_hash)
-            has_merge_commits_mock.assert_called_once_with(head_hash, base_hash)
+        get_base_revision.return_value = base_hash
+        get_subject_markers.return_value = ("feat(component):",)
+        has_merge_commits.return_value = True
+
+        self.assertEqual(1, merge_checks.main(head_hash=head_hash, base_ref=base_ref))
+        fetch_head_only.assert_called_once_with(base_ref)
+        get_base_revision.assert_called_once_with(base_ref)
+        fetch_full_history.assert_called_once()
+        get_subject_markers.assert_called_once_with(head_hash, base_hash)
+        has_merge_commits.assert_called_once_with(head_hash, base_hash)


### PR DESCRIPTION
## Reviewer

- [ ] for your information 
- [ ] process and function, acceptance criteria @zyv @stohrendorf
- [ ] implementation (code design, correctness, formatting) @zyv @stohrendorf 
- [ ] testing 

## Description

Wie in MD-5312 und https://github.com/moneymeets/action-merge-checks/pull/4#discussion_r623677756 besprochen. Ich habe noch überlegt ob man die Zeilen 

```python
get_base_revision.return_value = base_hash
get_subject_markers.return_value = ("feat(component):",)
has_merge_commits.return_value = False
```
refaktorieren kann, aber mir ist hier keine wirklich gute Lösung eingefallen. Freue mich auf euer Feedback!
