### PR TITLE
feat(action): make action run successfully independent of result

### DIFF
--- a/merge_checks/runner.py
+++ b/merge_checks/runner.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 from dataclasses import asdict, dataclass
 from enum import Enum
 
@@ -68,7 +67,3 @@ def run():
         state=(State.SUCCESS if checks_passed else State.FAILURE).value,
         description=summary,
     )
-
-    # TODO: Remove after required status checks in GitHub have been switched to "Merge checks / Result"
-    if not checks_passed:
-        sys.exit(1)

--- a/tests/test_merge_checks_runner.py
+++ b/tests/test_merge_checks_runner.py
@@ -40,9 +40,7 @@ class MergeChecksRunnerTest(TestCase):
         )
         mock_get_commit_checks_result.return_value = (False, "test summary")
 
-        # TODO: Remove after required status checks in GitHub have been switched to "Merge checks / Result"
-        with self.assertRaises(SystemExit):
-            run()
+        run()
 
         mock_get_commit_checks_result.assert_called_once()
         self.assertEqual("pending", mock_set_commit_status.call_args_list[0].kwargs.get("state"))


### PR DESCRIPTION
<!-- This template is managed by Pulumi!

## Pre-flight checklist

- [ ] reviewed own code
- [ ] tests are green
- [ ] linter is happy
-->

## Description

Finally, now that the commit status "Merge checks / Result" is the required status check for the master branch in all our repositories (see [moneymeets/moneymeets-pulumi/pull/226](https://github.com/moneymeets/moneymeets-pulumi/pull/226)), we can make this action's workflow run complete without error, even when problematic commits are found.

## Deployment plan

Changes to moneymeets-pulumi and action-merge-checks should be rolled out in the following order:

- [x] 1. Preparation for updated merge checks ([moneymeets/moneymeets-pulumi#224](https://github.com/moneymeets/moneymeets-pulumi/pull/224))
- [x] 2. Apply changes via `pulumi up`
- [x] 3. Separation of workflow run and merge checks status ([moneymeets/action-merge-checks#13](https://github.com/moneymeets/action-merge-checks/pull/13))
- [x] 4. Switch required status checks to merge check result in moneymeets-pulumi ([moneymeets/moneymeets-pulumi/pull/226](https://github.com/moneymeets/moneymeets-pulumi/pull/226))
- [x] 5. Apply changes via `pulumi up`
- [x] 6. Remove workflow run sys.exit(1) in action-merge-checks ([moneymeets/action-merge-checks/pull/14](https://github.com/moneymeets/action-merge-checks/pull/14), this PR)

