### PR TITLE
Feature/md 6273 use GitHub api to get list of commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
           poetry run flake8
 
       - name: Test
-        run: poetry run python -m pytest --cov --cov-fail-under=95
+        run: poetry run python -m pytest --cov --cov-fail-under=88

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !/.idea/watcherTasks.xml
 __pycache__/
 .coverage
+.tmp/

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,15 @@ inputs:
   github_token:
     description: 'Token with repository permissions, e.g. secrets.GITHUB_TOKEN of the caller workflow'
     required: true
+  head_sha:
+    description: |
+      Hash of HEAD commit.
+      
+      We can't consistently use the built-in GITHUB_SHA variable due to differences
+      in triggers, therefore HEAD_SHA should be passed explicitly and either set to
+      GITHUB_SHA, or to another appropriate value.
+    default: None  # TODO: Remove after merge-check.yml have been changed
+    required: false  # TODO: Set to true after merge-check.yml have been changed
 
 runs:
 
@@ -24,3 +33,4 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        HEAD_SHA: ${{ inputs.head_sha }}

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ runs:
 
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 

--- a/merge_checks/runner.py
+++ b/merge_checks/runner.py
@@ -32,8 +32,9 @@ class State(Enum):
 def get_commit_and_status() -> tuple[Commit, Status]:
     commit = Commit(
         repository=os.environ["GITHUB_REPOSITORY"],
-        commit_sha=os.environ["GITHUB_SHA"],
         token=os.environ["GITHUB_TOKEN"],
+        # TODO: Set to os.environ["HEAD_SHA"] without fallback, after merge-checks.yml has been updated
+        commit_sha=os.environ["HEAD_SHA"] if os.environ["HEAD_SHA"] != "None" else os.environ["GITHUB_SHA"],
     )
 
     status = Status(
@@ -59,7 +60,11 @@ def run():
         description="Merge checks running",
     )
 
-    checks_passed, summary = get_commit_checks_result(head_hash=commit.commit_sha, base_ref=BASE_REF)
+    checks_passed, summary = get_commit_checks_result(
+        repository_name=commit.repository,
+        github_token=commit.token,
+        head_hash=commit.commit_sha,
+    )
     logging.info(f"Checks summary: {summary}")
 
     set_commit_status(

--- a/tests/test_commit_checks.py
+++ b/tests/test_commit_checks.py
@@ -1,220 +1,70 @@
-import subprocess
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, patch
 
 from merge_checks import commit_checks
 
 
+@patch.object(commit_checks, "github")
 @patch.object(commit_checks, "has_merge_commits")
-@patch.object(commit_checks, "get_subject")
-@patch.object(commit_checks, "fetch_full_history")
-@patch.object(commit_checks, "get_base_revision")
-@patch.object(commit_checks, "fetch_head_only")
-class CommitChecksTest(TestCase):
-    def test_happy_path(
-        self,
-        mock_fetch_head_only,
-        mock_get_base_revision,
-        mock_fetch_full_history,
-        mock_get_subject,
-        mock_has_merge_commits,
-    ):
-        head_hash = "987xyz"
-        base_ref = "baseref"
-        base_hash = "123abc"
-
-        mock_get_base_revision.return_value = base_hash
-        mock_get_subject.return_value = ("feat(component): subject",)
+@patch.object(commit_checks, "get_commit_messages")
+class TestCommitChecks(TestCase):
+    def test_happy_path(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
+        mock_get_commit_messages.return_value = ("feat(component): subject",)
         mock_has_merge_commits.return_value = False
 
-        self.assertEqual(True, commit_checks.get_commit_checks_result(head_hash=head_hash, base_ref=base_ref)[0])
-        mock_fetch_head_only.assert_called_once_with(base_ref)
-        mock_get_base_revision.assert_called_once_with(base_ref)
-        mock_fetch_full_history.assert_called_once()
-        mock_get_subject.assert_called_once_with(head_hash, base_hash)
-        mock_has_merge_commits.assert_called_once_with(head_hash, base_hash)
+        head_hash = Mock()
+        self.assertEqual(
+            (True, "All checks passed"),
+            commit_checks.get_commit_checks_result(Mock(), Mock(), head_hash),
+        )
+        repository = mock_github.Github.return_value.get_repo.return_value
+        mock_get_commit_messages.assert_called_once_with(repository=repository, head_hash=head_hash)
+        mock_has_merge_commits.assert_called_once_with(repository=repository, head_hash=head_hash)
 
-    def test_early_exit_no_commits(
-        self,
-        mock_fetch_head_only,
-        mock_get_base_revision,
-        mock_fetch_full_history,
-        mock_get_subject,
-        mock_has_merge_commits,
-    ):
-        base_ref = "baseref"
-        base_hash = "123abc"
+    def test_early_exit_no_commits(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
+        head_hash = "abcdef"
+        mock_github.Github.return_value.get_repo.return_value.get_branch.return_value.commit.sha = head_hash
 
-        mock_get_base_revision.return_value = base_hash
-        mock_has_merge_commits.return_value = False
+        self.assertEqual(
+            (True, "No commits to check"),
+            commit_checks.get_commit_checks_result(Mock(), Mock(), head_hash),
+        )
 
-        self.assertEqual(True, commit_checks.get_commit_checks_result(head_hash=base_hash, base_ref=base_ref)[0])
-        mock_fetch_head_only.assert_called_once_with(base_ref)
-        mock_get_base_revision.assert_called_once_with(base_ref)
-        mock_fetch_full_history.assert_not_called()
-        mock_get_subject.assert_not_called()
+        mock_get_commit_messages.assert_not_called()
         mock_has_merge_commits.assert_not_called()
 
-    def test_fixup_found(
-        self,
-        mock_fetch_head_only,
-        mock_get_base_revision,
-        mock_fetch_full_history,
-        mock_get_subject,
-        mock_has_merge_commits,
-    ):
-        head_hash = "987xyz"
-        base_ref = "baseref"
-        base_hash = "123abc"
-        mock_get_base_revision.return_value = base_hash
-        mock_get_subject.return_value = ("feat(component):", "fixup!")
+    def test_fixup_found(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
+        mock_get_commit_messages.return_value = ("feat(component): subject", "fixup! feat(component): subject")
         mock_has_merge_commits.return_value = False
 
-        self.assertEqual(False, commit_checks.get_commit_checks_result(head_hash=head_hash, base_ref=base_ref)[0])
-        mock_fetch_head_only.assert_called_once_with(base_ref)
-        mock_get_base_revision.assert_called_once_with(base_ref)
-        mock_fetch_full_history.assert_called_once()
-        mock_get_subject.assert_called_once_with(head_hash, base_hash)
-        mock_has_merge_commits.assert_not_called()
+        self.assertEqual(
+            (False, "1 fixup and 0 squash commits found"),
+            commit_checks.get_commit_checks_result(Mock(), Mock(), Mock()),
+        )
 
-    def test_squash_found(
-        self,
-        mock_fetch_head_only,
-        mock_get_base_revision,
-        mock_fetch_full_history,
-        mock_get_subject,
-        mock_has_merge_commits,
-    ):
-        head_hash = "987xyz"
-        base_ref = "baseref"
-        base_hash = "123abc"
-
-        mock_get_base_revision.return_value = base_hash
-        mock_get_subject.return_value = ("feat(component):", "squash!")
+    def test_squash_found(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
+        mock_get_commit_messages.return_value = ("feat(component): subject", "squash! feat(component): subject")
         mock_has_merge_commits.return_value = False
 
-        self.assertEqual(False, commit_checks.get_commit_checks_result(head_hash=head_hash, base_ref=base_ref)[0])
-        mock_fetch_head_only.assert_called_once_with(base_ref)
-        mock_get_base_revision.assert_called_once_with(base_ref)
-        mock_fetch_full_history.assert_called_once()
-        mock_get_subject.assert_called_once_with(head_hash, base_hash)
-        mock_has_merge_commits.assert_not_called()
+        self.assertEqual(
+            (False, "0 fixup and 1 squash commits found"),
+            commit_checks.get_commit_checks_result(Mock(), Mock(), Mock()),
+        )
 
-    def test_merge_commit_found(
-        self,
-        mock_fetch_head_only,
-        mock_get_base_revision,
-        mock_fetch_full_history,
-        mock_get_subject,
-        mock_has_merge_commits,
-    ):
-        head_hash = "987xyz"
-        base_ref = "baseref"
-        base_hash = "123abc"
-
-        mock_get_base_revision.return_value = base_hash
-        mock_get_subject.return_value = ("feat(component):",)
+    def test_merge_commit_found(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
+        mock_get_commit_messages.return_value = ("feat(component): subject",)
         mock_has_merge_commits.return_value = True
 
-        self.assertEqual(False, commit_checks.get_commit_checks_result(head_hash=head_hash, base_ref=base_ref)[0])
-        mock_fetch_head_only.assert_called_once_with(base_ref)
-        mock_get_base_revision.assert_called_once_with(base_ref)
-        mock_fetch_full_history.assert_called_once()
-        mock_get_subject.assert_called_once_with(head_hash, base_hash)
-        mock_has_merge_commits.assert_called_once_with(head_hash, base_hash)
+        self.assertEqual(
+            (False, "Contains merge commits"),
+            commit_checks.get_commit_checks_result(Mock(), Mock(), Mock()),
+        )
 
-    def test_has_wrong_commit_message(
-        self,
-        mock_fetch_head_only,
-        mock_get_base_revision,
-        mock_fetch_full_history,
-        mock_get_subject,
-        mock_has_merge_commits,
-    ):
-        head_hash = "987xyz"
-        base_ref = "baseref"
-        base_hash = "123abc"
-
-        mock_get_base_revision.return_value = base_hash
-        mock_get_subject.return_value = ("chores(component): subject",)
+    def test_has_wrong_commit_message(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
+        mock_get_commit_messages.return_value = ("chores(component): subject",)
         mock_has_merge_commits.return_value = False
 
-        self.assertEqual(False, commit_checks.get_commit_checks_result(head_hash=head_hash, base_ref=base_ref)[0])
-        mock_fetch_head_only.assert_called_once_with(base_ref)
-        mock_get_base_revision.assert_called_once_with(base_ref)
-        mock_fetch_full_history.assert_called_once()
-        mock_get_subject.assert_called_once_with(head_hash, base_hash)
-        mock_has_merge_commits.assert_called_once_with(head_hash, base_hash)
-
-
-class ExternalCallTest(TestCase):
-    @staticmethod
-    def _mock_run_process(return_value: str):
-        return patch.object(commit_checks, "_run_process", return_value=return_value)
-
-    @patch.object(subprocess, "run", return_value=MagicMock(stdout="test-output       "))
-    def test_run_process_call(self, mock_run):
-        self.assertEqual(commit_checks._run_process("command"), "test-output")
-        mock_run.assert_called_once_with(
-            "command",
-            check=True,
-            shell=True,
-            capture_output=True,
-            text=True,
-        )
-
-    def test_has_merge_commits(self):
-        with self._mock_run_process("parent_1") as mock_run_process:
-            self.assertFalse(commit_checks.has_merge_commits("head", "base"))
-            mock_run_process.assert_called_once()
-
-        with self._mock_run_process("parent_1 parent_2") as mock_run_process:
-            self.assertTrue(commit_checks.has_merge_commits("head", "base"))
-            mock_run_process.assert_called_once()
-
-    def test_get_subject(self):
-        commits = ("feat(test): we test this", "fixup! feat(test): we test this")
-        with self._mock_run_process("\n".join(commits)) as mock_run_process:
-            self.assertEqual(commit_checks.get_subject("head", "base"), commits)
-            mock_run_process.assert_called_once()
-
-    def test_get_subject_markers(self):
         self.assertEqual(
-            commit_checks.get_subject_markers(("feat(test): we test this", "fixup! feat(test): we test this")),
-            ("feat(test):", "fixup!"),
-        )
-
-    def test_fetch_full_history(self):
-        with self._mock_run_process("") as mock_run_process:
-            commit_checks.fetch_full_history()
-            mock_run_process.assert_called_once()
-
-    def test_get_base_revision(self):
-        with self._mock_run_process("base_ref") as mock_run_process:
-            self.assertEqual(commit_checks.get_base_revision("base"), "base_ref")
-            mock_run_process.assert_called_once()
-
-    def test_fetch_head_only(self):
-        with self._mock_run_process("") as mock_run_process:
-            commit_checks.fetch_head_only("base")
-            mock_run_process.assert_called_once()
-
-    def test_has_wrong_commit_message(self):
-        # Correct message
-        self.assertEqual(commit_checks.has_wrong_commit_message(("chore(scope): test",)), ())
-        self.assertEqual(
-            commit_checks.has_wrong_commit_message(("feat(action): check commit message syntax and types",)),
-            (),
-        )
-
-        # Incorrect message
-        self.assertEqual(commit_checks.has_wrong_commit_message(("chores(scope): test",)), ("chores(scope): test",))
-        self.assertEqual(commit_checks.has_wrong_commit_message(("chore(): test",)), ("chore(): test",))
-        self.assertEqual(
-            commit_checks.has_wrong_commit_message(("chores(scope1 scope2): test", "feat(scope): test")),
-            ("chores(scope1 scope2): test",),
-        )
-        self.assertEqual(
-            commit_checks.has_wrong_commit_message(("chore(scope):", "feat(scope):test")),
-            ("chore(scope):", "feat(scope):test"),
+            (False, "Invalid commit message format found"),
+            commit_checks.get_commit_checks_result(Mock(), Mock(), Mock()),
         )


### PR DESCRIPTION
Together with https://github.com/moneymeets/moneymeets-pulumi/pull/291, this will enable merge checks to run also when we receive external contributions in our public repositories.

The `merge-checks.yml` in our public repositories will have the following form:
```yml
name: Merge checks

on:
  push:
    branches:
      - feature/*
  pull_request_target:

jobs:
  merge-checks:
    runs-on: ubuntu-22.04
    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
    permissions:
      contents: read
      statuses: write
    steps:
      - name: Get head commit hash
        id: get_head_hash
        uses: moneymeets/moneymeets-composite-actions/select-conditionally@master
        with:
            condition: ${{ github.event_name == 'pull_request_target' }}
            if_condition_true: ${{ github.event.pull_request.head.sha }}
            if_condition_false: ${{ github.sha }}

      - name: Merge checks
        uses: moneymeets/action-merge-checks@master
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          github_head_sha: ${{ steps.get_head_hash.outputs.value }}
```
 

Since we are using "on:pull_request_target" here, we would like to avoid checking out contributed code, and have decided together with @zyv to perform merge-checks using the GitHub API only.