### PR TITLE
Feature/compare base with head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Python + Poetry
-        uses: moneymeets/action-setup-python-poetry@master
+      - uses: moneymeets/action-setup-python-poetry@master
 
-      - name: Lint
-        run: |
-          find . -name '*.py' | xargs poetry run add-trailing-comma --py36-plus
-          poetry run flake8
+      - uses: moneymeets/moneymeets-composite-actions/lint-python@master
 
-      - name: Test
-        run: poetry run python -m pytest --cov --cov-fail-under=93
+      - run: poetry run python -m pytest --cov --cov-fail-under=93

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
           poetry run flake8
 
       - name: Test
-        run: poetry run python -m pytest --cov --cov-fail-under=88
+        run: poetry run python -m pytest --cov --cov-fail-under=93

--- a/merge_checks/commit_checks.py
+++ b/merge_checks/commit_checks.py
@@ -2,7 +2,6 @@ import logging
 import re
 from typing import Sequence
 
-import github
 from github.Commit import Commit
 from github.Repository import Repository
 
@@ -11,13 +10,17 @@ ALLOWED_COMMIT_MESSAGE_TYPES = ("chore", "ci", "docs", "feat", "fix", "perf", "r
 LOGGING_PREFIX = "\n  "
 
 
-def get_commits(repository: Repository, head_hash: str) -> Sequence[Commit]:
-    return tuple(set(repository.get_commits(head_hash)) - set(repository.get_commits(repository.default_branch)))
+def get_base_sha(repository: Repository) -> str:
+    return repository.get_branch(repository.default_branch).commit.sha
 
 
-def get_commit_messages(repository: Repository, head_hash: str) -> Sequence[str]:
+def get_commits(repository: Repository, base_sha: str, head_hash: str) -> Sequence[Commit]:
+    return tuple(repository.compare(base=base_sha, head=head_hash).commits)
+
+
+def get_commit_messages(commits: Sequence[Commit]) -> Sequence[str]:
     logging.info("Getting commit messages...")
-    return tuple(commit.commit.message for commit in get_commits(repository=repository, head_hash=head_hash))
+    return tuple(commit.commit.message for commit in commits)
 
 
 def get_subject_markers(subjects: Sequence[str]) -> Sequence[str]:
@@ -25,12 +28,9 @@ def get_subject_markers(subjects: Sequence[str]) -> Sequence[str]:
     return tuple(line.split(maxsplit=1)[0] for line in subjects)
 
 
-def has_merge_commits(repository: Repository, head_hash: str) -> bool:
+def has_merge_commits(commits: Sequence[Commit]) -> bool:
     logging.info("Checking for merge commits...")
-    return any(
-        len(parents) > 1
-        for parents in tuple(commit.parents for commit in get_commits(repository=repository, head_hash=head_hash))
-    )
+    return any(len(parents) > 1 for parents in tuple(commit.parents for commit in commits))
 
 
 def has_wrong_commit_message(subject_markers: Sequence[str]) -> Sequence[str]:
@@ -41,15 +41,8 @@ def has_wrong_commit_message(subject_markers: Sequence[str]) -> Sequence[str]:
     )
 
 
-def get_commit_checks_result(repository_name: str, github_token: str, head_hash: str) -> tuple[bool, str]:
-
-    repository = github.Github(login_or_token=github_token).get_repo(repository_name)
-
-    if head_hash == repository.get_branch(repository.default_branch).commit.sha:
-        logging.warning(f"HEAD identical with {repository.default_branch}, no commits to check")
-        return True, "No commits to check"
-
-    subjects = get_commit_messages(repository=repository, head_hash=head_hash)
+def get_commit_checks_result(commits: Sequence[Commit]) -> tuple[bool, str]:
+    subjects = get_commit_messages(commits)
     logging.info(
         f"Found the following commit messages in branch:{LOGGING_PREFIX}{LOGGING_PREFIX.join(subjects)}",
     )
@@ -65,7 +58,7 @@ def get_commit_checks_result(repository_name: str, github_token: str, head_hash:
     else:
         logging.info("No fixups or squashes found, check passed!")
 
-    if has_merge_commits(repository=repository, head_hash=head_hash):
+    if has_merge_commits(commits):
         return False, "Contains merge commits"
     else:
         logging.info("Branch does not contain merge commits, check passed!")

--- a/merge_checks/runner.py
+++ b/merge_checks/runner.py
@@ -34,8 +34,7 @@ def get_commit_and_status() -> tuple[Commit, Status]:
     commit = Commit(
         repository=os.environ["GITHUB_REPOSITORY"],
         token=os.environ["GITHUB_TOKEN"],
-        # TODO: Set to os.environ["HEAD_SHA"] without fallback, after merge-checks.yml has been updated
-        commit_sha=os.environ["HEAD_SHA"] if os.environ["HEAD_SHA"] != "None" else os.environ["GITHUB_SHA"],
+        commit_sha=os.environ["HEAD_SHA"],
     )
 
     status = Status(

--- a/merge_checks/runner.py
+++ b/merge_checks/runner.py
@@ -3,7 +3,10 @@ import os
 from dataclasses import asdict, dataclass
 from enum import Enum
 
-from .commit_checks import get_commit_checks_result
+import github
+from github.Repository import Repository
+
+from .commit_checks import get_base_sha, get_commit_checks_result, get_commits
 from .commit_status_setter import set_commit_status
 
 BASE_REF = "master"
@@ -45,6 +48,10 @@ def get_commit_and_status() -> tuple[Commit, Status]:
     return commit, status
 
 
+def get_repository(commit: Commit) -> Repository:
+    return github.Github(login_or_token=commit.token).get_repo(commit.repository)
+
+
 def run():
     logging.basicConfig(
         level=logging.INFO,
@@ -60,15 +67,20 @@ def run():
         description="Merge checks running",
     )
 
+    repository = get_repository(commit=commit)
+    base_sha = get_base_sha(repository=repository)
+
+    if commit.commit_sha == base_sha:
+        logging.warning(f"HEAD identical with {repository.default_branch}, no commits to check")
+        return True, "No commits to check"
+
     checks_passed, summary = get_commit_checks_result(
-        repository_name=commit.repository,
-        github_token=commit.token,
-        head_hash=commit.commit_sha,
+        commits=get_commits(repository=repository, base_sha=base_sha, head_hash=commit.commit_sha),
     )
     logging.info(f"Checks summary: {summary}")
 
     set_commit_status(
         **(asdict(commit) | asdict(status)),
-        state=(State.SUCCESS if checks_passed else State.FAILURE).value,
+        state=str((State.SUCCESS if checks_passed else State.FAILURE).value),
         description=summary,
     )

--- a/merge_checks/runner.py
+++ b/merge_checks/runner.py
@@ -9,8 +9,6 @@ from github.Repository import Repository
 from .commit_checks import get_base_sha, get_commit_checks_result, get_commits
 from .commit_status_setter import set_commit_status
 
-BASE_REF = "master"
-
 
 @dataclass
 class Commit:

--- a/tests/test_commit_checks.py
+++ b/tests/test_commit_checks.py
@@ -1,70 +1,63 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from merge_checks import commit_checks
+from merge_checks.commit_checks import get_base_sha
 
 
-@patch.object(commit_checks, "github")
-@patch.object(commit_checks, "has_merge_commits")
-@patch.object(commit_checks, "get_commit_messages")
-class TestCommitChecks(TestCase):
-    def test_happy_path(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
-        mock_get_commit_messages.return_value = ("feat(component): subject",)
-        mock_has_merge_commits.return_value = False
+class TestGetBaseSha(TestCase):
+    def test_get_base_sha_returns_expected_sha(self):
+        mock_repository = Mock()
+        mock_repository.get_branch.return_value.commit.sha = "abc123"
+        self.assertEqual("abc123", get_base_sha(mock_repository))
 
-        head_hash = Mock()
+
+class TestGetCommitChecksResult(TestCase):
+    def test_happy_path(self):
+        mock_commit = Mock()
+        mock_commit.commit.message = "feat(component): subject"
+        mock_commit.parents = (Mock(),)
+
         self.assertEqual(
             (True, "All checks passed"),
-            commit_checks.get_commit_checks_result(Mock(), Mock(), head_hash),
-        )
-        repository = mock_github.Github.return_value.get_repo.return_value
-        mock_get_commit_messages.assert_called_once_with(repository=repository, head_hash=head_hash)
-        mock_has_merge_commits.assert_called_once_with(repository=repository, head_hash=head_hash)
-
-    def test_early_exit_no_commits(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
-        head_hash = "abcdef"
-        mock_github.Github.return_value.get_repo.return_value.get_branch.return_value.commit.sha = head_hash
-
-        self.assertEqual(
-            (True, "No commits to check"),
-            commit_checks.get_commit_checks_result(Mock(), Mock(), head_hash),
+            commit_checks.get_commit_checks_result(commits=(mock_commit,)),
         )
 
-        mock_get_commit_messages.assert_not_called()
-        mock_has_merge_commits.assert_not_called()
-
-    def test_fixup_found(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
-        mock_get_commit_messages.return_value = ("feat(component): subject", "fixup! feat(component): subject")
-        mock_has_merge_commits.return_value = False
+    def test_fixup_found(self):
+        mock_commit = Mock()
+        mock_commit.commit.message = "fixup! feat(component): subject"
 
         self.assertEqual(
             (False, "1 fixup and 0 squash commits found"),
-            commit_checks.get_commit_checks_result(Mock(), Mock(), Mock()),
+            commit_checks.get_commit_checks_result(commits=(mock_commit,)),
         )
 
-    def test_squash_found(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
-        mock_get_commit_messages.return_value = ("feat(component): subject", "squash! feat(component): subject")
-        mock_has_merge_commits.return_value = False
+    def test_squash_found(self):
+        mock_commit = Mock()
+        mock_commit.commit.message = "squash! feat(component): subject"
 
         self.assertEqual(
             (False, "0 fixup and 1 squash commits found"),
-            commit_checks.get_commit_checks_result(Mock(), Mock(), Mock()),
+            commit_checks.get_commit_checks_result(commits=(mock_commit,)),
         )
 
-    def test_merge_commit_found(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
-        mock_get_commit_messages.return_value = ("feat(component): subject",)
-        mock_has_merge_commits.return_value = True
+    #
+    def test_merge_commit_found(self):
+        mock_commit = Mock()
+        mock_commit.commit.message = "feat(component): subject"
+        mock_commit.parents = (Mock(), Mock())
 
         self.assertEqual(
             (False, "Contains merge commits"),
-            commit_checks.get_commit_checks_result(Mock(), Mock(), Mock()),
+            commit_checks.get_commit_checks_result(commits=(mock_commit,)),
         )
 
-    def test_has_wrong_commit_message(self, mock_get_commit_messages, mock_has_merge_commits, mock_github):
-        mock_get_commit_messages.return_value = ("chores(component): subject",)
-        mock_has_merge_commits.return_value = False
+    def test_has_wrong_commit_message(self):
+        mock_commit = Mock()
+        mock_commit.commit.message = "chores(component): subject"
+        mock_commit.parents = (Mock(),)
 
         self.assertEqual(
             (False, "Invalid commit message format found"),
-            commit_checks.get_commit_checks_result(Mock(), Mock(), Mock()),
+            commit_checks.get_commit_checks_result(commits=(mock_commit,)),
         )

--- a/tests/test_commit_checks.py
+++ b/tests/test_commit_checks.py
@@ -23,6 +23,16 @@ class TestGetCommitChecksResult(TestCase):
             commit_checks.get_commit_checks_result(commits=(mock_commit,)),
         )
 
+    def test_revert_commit_passes_checks(self):
+        mock_commit = Mock()
+        mock_commit.commit.message = 'Revert "feat(compenent): subject"'
+        mock_commit.parents = (Mock(),)
+
+        self.assertEqual(
+            (True, "All checks passed"),
+            commit_checks.get_commit_checks_result(commits=(mock_commit,)),
+        )
+
     def test_fixup_found(self):
         mock_commit = Mock()
         mock_commit.commit.message = "fixup! feat(component): subject"

--- a/tests/test_merge_checks_runner.py
+++ b/tests/test_merge_checks_runner.py
@@ -6,6 +6,7 @@ from merge_checks.runner import Commit, Status, run
 
 
 @patch.object(runner, "get_commit_checks_result")
+@patch.object(runner, "get_repository")
 @patch.object(runner, "get_commit_and_status")
 @patch.object(runner, "set_commit_status")
 class MergeChecksRunnerTest(TestCase):
@@ -13,6 +14,7 @@ class MergeChecksRunnerTest(TestCase):
         self,
         mock_set_commit_status,
         mock_get_commit_and_status,
+        mock_get_repository,
         mock_get_commit_checks_result,
     ):
         mock_get_commit_and_status.return_value = (
@@ -23,7 +25,7 @@ class MergeChecksRunnerTest(TestCase):
 
         run()
 
-        mock_get_commit_checks_result.assert_called_once()
+        mock_get_repository.assert_called_once()
         self.assertEqual("pending", mock_set_commit_status.call_args_list[0].kwargs.get("state"))
         mock_get_commit_checks_result.assert_called_once()
         self.assertEqual("success", mock_set_commit_status.call_args_list[1].kwargs.get("state"))
@@ -32,6 +34,7 @@ class MergeChecksRunnerTest(TestCase):
         self,
         mock_set_commit_status,
         mock_get_commit_and_status,
+        mock_get_repository,
         mock_get_commit_checks_result,
     ):
         mock_get_commit_and_status.return_value = (
@@ -42,7 +45,7 @@ class MergeChecksRunnerTest(TestCase):
 
         run()
 
-        mock_get_commit_checks_result.assert_called_once()
+        mock_get_repository.assert_called_once()
         self.assertEqual("pending", mock_set_commit_status.call_args_list[0].kwargs.get("state"))
         mock_get_commit_checks_result.assert_called_once()
         self.assertEqual("failure", mock_set_commit_status.call_args_list[1].kwargs.get("state"))


### PR DESCRIPTION
Instead of querying all commits, which leads to a lot of API requests and we exceeded our rate limit, it is possible to use the compare function to get a list of commits for the branch.

```python
tuple(repository.compare(base=base_sha, head=head_hash).commits)
```

Feel free to update the tests and improve the test coverage. :)