### PR TITLE
fix(action): correctly handle no commits to check

### DIFF
--- a/merge_checks/runner.py
+++ b/merge_checks/runner.py
@@ -69,11 +69,11 @@ def run():
 
     if commit.commit_sha == base_sha:
         logging.warning(f"HEAD identical with {repository.default_branch}, no commits to check")
-        return True, "No commits to check"
-
-    checks_passed, summary = get_commit_checks_result(
-        commits=get_commits(repository=repository, base_sha=base_sha, head_hash=commit.commit_sha),
-    )
+        checks_passed, summary = (True, "No commits to check")
+    else:
+        checks_passed, summary = get_commit_checks_result(
+            commits=get_commits(repository=repository, base_sha=base_sha, head_hash=commit.commit_sha),
+        )
     logging.info(f"Checks summary: {summary}")
 
     set_commit_status(

--- a/tests/test_merge_checks_runner.py
+++ b/tests/test_merge_checks_runner.py
@@ -5,73 +5,59 @@ from merge_checks import runner
 from merge_checks.runner import Commit, Status, run
 
 
-@patch.object(runner, "get_commit_checks_result")
-@patch.object(runner, "get_base_sha")
-@patch.object(runner, "get_repository")
-@patch.object(runner, "get_commit_and_status")
-@patch.object(runner, "set_commit_status")
 class MergeChecksRunnerTest(TestCase):
-    def test_result_state_success(
+    @patch.object(runner, "get_commit_checks_result")
+    @patch.object(runner, "get_base_sha")
+    @patch.object(runner, "get_repository")
+    @patch.object(runner, "get_commit_and_status")
+    @patch.object(runner, "set_commit_status")
+    def assertExpectedCallsAndResult(
         self,
         mock_set_commit_status,
         mock_get_commit_and_status,
         mock_get_repository,
         mock_get_base_sha,
         mock_get_commit_checks_result,
+        commit_checks_result,
+        base_sha,
+        n_expected_commit_check_calls,
+        expected_commit_state,
     ):
         mock_get_commit_and_status.return_value = (
             Commit(repository="test", commit_sha="123", token="456"),
             Status(status_name="test status", details_url="example.com"),
         )
-        mock_get_commit_checks_result.return_value = (True, "test summary")
+        mock_get_commit_checks_result.return_value = (commit_checks_result, "test summary")
+        mock_get_base_sha.return_value = base_sha
 
         run()
 
         mock_get_repository.assert_called_once()
         mock_get_base_sha.assert_called_once()
         self.assertEqual("pending", mock_set_commit_status.call_args_list[0].kwargs.get("state"))
-        mock_get_commit_checks_result.assert_called_once()
-        self.assertEqual("success", mock_set_commit_status.call_args_list[1].kwargs.get("state"))
+        self.assertEqual(len(mock_get_commit_checks_result.call_args_list), n_expected_commit_check_calls)
+        self.assertEqual(expected_commit_state, mock_set_commit_status.call_args_list[1].kwargs.get("state"))
 
-    def test_no_commits_to_check(
-        self,
-        mock_set_commit_status,
-        mock_get_commit_and_status,
-        mock_get_repository,
-        mock_get_base_sha,
-        mock_get_commit_checks_result,
-    ):
-        mock_get_commit_and_status.return_value = (
-            Commit(repository="test", commit_sha="123", token="456"),
-            Status(status_name="test status", details_url="example.com"),
+    def test_result_state_success(self):
+        self.assertExpectedCallsAndResult(
+            commit_checks_result=True,
+            base_sha="456",
+            n_expected_commit_check_calls=1,
+            expected_commit_state="success",
         )
-        mock_get_base_sha.return_value = "123"
-        run()
 
-        mock_get_repository.assert_called_once()
-        mock_get_base_sha.assert_called_once()
-        self.assertEqual("pending", mock_set_commit_status.call_args_list[0].kwargs.get("state"))
-        mock_get_commit_checks_result.assert_not_called()
-        self.assertEqual("success", mock_set_commit_status.call_args_list[1].kwargs.get("state"))
-
-    def test_result_state_failure(
-        self,
-        mock_set_commit_status,
-        mock_get_commit_and_status,
-        mock_get_repository,
-        mock_get_base_sha,
-        mock_get_commit_checks_result,
-    ):
-        mock_get_commit_and_status.return_value = (
-            Commit(repository="test", commit_sha="123", token="456"),
-            Status(status_name="test status", details_url="example.com"),
+    def test_no_commits_to_check(self):
+        self.assertExpectedCallsAndResult(
+            commit_checks_result=True,
+            base_sha="123",
+            n_expected_commit_check_calls=0,
+            expected_commit_state="success",
         )
-        mock_get_commit_checks_result.return_value = (False, "test summary")
 
-        run()
-
-        mock_get_repository.assert_called_once()
-        mock_get_base_sha.assert_called_once()
-        self.assertEqual("pending", mock_set_commit_status.call_args_list[0].kwargs.get("state"))
-        mock_get_commit_checks_result.assert_called_once()
-        self.assertEqual("failure", mock_set_commit_status.call_args_list[1].kwargs.get("state"))
+    def test_result_state_failure(self):
+        self.assertExpectedCallsAndResult(
+            commit_checks_result=False,
+            base_sha="456",
+            n_expected_commit_check_calls=1,
+            expected_commit_state="failure",
+        )


### PR DESCRIPTION
Fixes the issue observed in pipelines for https://github.com/moneymeets/moneymeets-reporting/commit/d3bfccbfb1d499e536ed146aac5edbcc66d433a1. The regression stems from a recent change in action-merge-checks. I have updated the unit tests to better cover the run() method as well.