### PR TITLE
Feature/do no use checks in python setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,7 @@ runs:
     - uses: moneymeets/action-setup-python-poetry@master
       with:
         working_directory: ${{ github.action_path }}
+        with_checks: 'false'
         # ToDo: Re-enable cache when https://github.com/actions/setup-python/issues/361 is fixed
         poetry_cache_enabled: 'false'
 


### PR DESCRIPTION
We do not want to perform checks (e.g. Poetry version downgrade) when using the setup action outside of a CI workflow, for example in the action here. See also https://github.com/moneymeets/action-setup-python-poetry/pull/21.